### PR TITLE
docs: Fix filetype name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ return {
       -- optional, but highly recommended
       -- `render-markdown.nvim` will auto-attach to lazy.nvim `ft` filetypes
       'MeanderingProgrammer/render-markdown.nvim',
-      ft = { 'codecompanion', 'codecompanion-ui' },
+      ft = { 'codecompanion', 'codecompanion_input' },
     },
   },
   opts = {


### PR DESCRIPTION
Corrects the filetype from `codecompanion-ui` to `codecompanion_input` in README.